### PR TITLE
FIX: LanguageClient-neovim deserializing issue

### DIFF
--- a/src/nimlsppkg/base_protocol.nim
+++ b/src/nimlsppkg/base_protocol.nim
@@ -15,8 +15,7 @@ proc sendFrame*(s: Stream, frame: string) =
   when defined(debugCommunication):
     stderr.write(frame)
     stderr.write("\n")
-  s.write "Content-Length: " & $frame.len & "\r\n\r\n" &
-                      frame & "\r\n\r\n"
+  s.write "Content-Length: " & $frame.len & "\r\n\r\n" & frame
   s.flush
 
 proc sendJson*(s: Stream, data: JsonNode) =


### PR DESCRIPTION
I was having trouble using this in vim/neovim due to some deserializing issue. After digging around for a while I found the offending code seemed to be two newlines after the message. It is working for me now, but please try it yourself in your client to see if it works for you as well!

And thanks for making nim an awesome experience in vim!