### PR TITLE
fixes bug with textDocument/definition on LanguageClient-neovim

### DIFF
--- a/src/nimlsppkg/messages2.nim
+++ b/src/nimlsppkg/messages2.nim
@@ -190,6 +190,15 @@ jsonSchema:
   TextDocumentPositionParams:
     textDocument: TextDocumentIdentifier
     position: Position
+    buftype?: string # Added by LanguageCLient-neovim erroneously
+    character?: int # Added by LanguageCLient-neovim erroneously
+    filename?: string # Added by LanguageCLient-neovim erroneously
+    gotoCmd?: string or nil # Added by LanguageCLient-neovim erroneously
+    handle?: bool # Added by LanguageCLient-neovim erroneously
+    languageId?: string # Added by LanguageCLient-neovim erroneously
+    line?: int # Added by LanguageCLient-neovim erroneously
+    "method"?: string # Added by LanguageCLient-neovim erroneously
+    text?: string[] # Added by LanguageCLient-neovim erroneously
 
   DocumentFilter:
     language?: string


### PR DESCRIPTION
It seems like LanguageClient-neovim sends extra data on the textDocument/definition request, which casues the server to fail the validation. I added those fields as optionals to the message schema and it seems to solve the issue.

I also found that I was getting constant errors about LanguageServer-neovim failing to deserialize the position params when it received a `-1`, as it expects an `u64`. Passing 0 instead seems to stop the constant errors.