### PR TITLE
Readme: fix git submodule clone command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Nim repository. This means you can either clone the Nim repository with
 
 .. code:: bash
 
-   git submodule update --recursive --remote
+   git submodule update --init --recursive
 
 Or if you don't want a full clone of the Nim sources you can copy just the
 nimsuggest folder into the `Nim` folder in `src/nimlsppkg`. This means the


### PR DESCRIPTION
The previously listed `git submodule` command did not work as advertised, doing nothing when executed on a newly cloned nimlsp repository. Instead, the newly proposed command actually clones the Nim repository (as suggested on stackoverflow: https://stackoverflow.com/a/53015726), as confirmed by the following output from git:

    C:\prog\nimlsp>git submodule update --init --recursive
    Submodule 'src/nimlsppkg/Nim' (https://github.com/nim-lang/Nim.git) registered for path 'src/nimlsppkg/Nim'
    Cloning into 'C:/prog/nimlsp/src/nimlsppkg/Nim'...
    Submodule path 'src/nimlsppkg/Nim': checked out '5b98afb8a8120b697fac625fd691f3484c328b23'