### PR TITLE
fix parsing of file URIs on Windows

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -108,11 +108,13 @@ type Certainty = enum
   Nimble
 
 proc getProjectFile(file: string): string =
-  let (dir, _, _) = file.splitFile()
+  result = file
+  when defined(windows):
+    result.removePrefix "/"   # ugly fix to "/C:/foo/bar" paths from "file:///C:/foo/bar"
+  let (dir, _, _) = result.splitFile()
   var
     path = dir
     certainty = None
-  result = file
   while path.len > 0 and path != "/":
     let
       (dir, fname, ext) = path.splitFile()

--- a/tests/tnimlsp.nim
+++ b/tests/tnimlsp.nim
@@ -1,5 +1,5 @@
 import unittest
-import os, osproc, streams, options, json, posix
+import os, osproc, streams, options, json
 import .. / src / nimlsppkg / baseprotocol
 include .. / src / nimlsppkg / messages
 
@@ -13,7 +13,7 @@ suite "Nim LSP basic operation":
   test "Nim LSP can be initialised":
     var ir = create(RequestMessage, "2.0", 0, "initialize", some(
       create(InitializeParams,
-        processId = getpid().int,
+        processId = getCurrentProcessId(),
         rootPath = none(string),
         rootUri = "file:///tmp/",
         initializationOptions = none(JsonNode),


### PR DESCRIPTION
On Windows, file URIs look like below:

    file:///C:/foo/bar

Just stripping the `file://` prefix from such URIs, as was done
previously, produces strings that are not correct Windows paths, for
example:

    /C:/foo/bar

This change removes the spurious "/" prefix from paths on Windows.

Fixes #23.