### PR TITLE
Change file type of README from json to js.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ overlapping features or achieve this in another way please update this section.
 
 Now in order to set up LSP itself enter it's settings and add this:
 
-.. code:: json
+.. code:: js
 
    {
       "clients":


### PR DESCRIPTION
README has syntax error.
Json does not have the comment syntax.
I think that you should remove red highlight syntax error.