### PR TITLE
decodeUrl for getProjectFile

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -5,6 +5,7 @@ import tables
 import strutils
 import os
 import hashes
+import uri
 
 const
   storage = getTempDir() / "nimlsp"
@@ -123,7 +124,7 @@ type Certainty = enum
   Nimble
 
 proc getProjectFile(file: string): string =
-  result = file
+  result = file.decodeUrl
   when defined(windows):
     result.removePrefix "/"   # ugly fix to "/C:/foo/bar" paths from "file:///C:/foo/bar"
   let (dir, _, _) = result.splitFile()


### PR DESCRIPTION
Create clean PR for this, I confirmed `result.removePrefix "/"` is needed on windows. otherwise`nimsuggest ` will not initialise properly