### PR TITLE
Fix warnings emitted by Nim's v1.4 compiler

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -163,7 +163,7 @@ if paramCount() == 1:
       echo "nimlsp v", version
       quit 0
     else: nimpath = expandFilename(paramStr(1))
-if not existsFile(nimpath / "config/nim.cfg"):
+if not fileExists(nimpath / "config/nim.cfg"):
   stderr.write "Unable to find \"config/nim.cfg\" in \"" & nimpath & "\". " &
     "Supply the Nim project folder by adding it as an argument.\n"
   quit 1

--- a/src/nimlsppkg/baseprotocol.nim
+++ b/src/nimlsppkg/baseprotocol.nim
@@ -1,7 +1,7 @@
 import streams, strutils, parseutils, json
 
 type
-  BaseProtocolError* = object of Exception
+  BaseProtocolError* = object of Defect
 
   MalformedFrame* = object of BaseProtocolError
   UnsupportedEncoding* = object of BaseProtocolError

--- a/src/nimlsppkg/utfmapping.nim
+++ b/src/nimlsppkg/utfmapping.nim
@@ -1,4 +1,3 @@
-import tables
 import unicode
 
 type FingerTable = seq[tuple[u16pos, offset: int]]


### PR DESCRIPTION
I've included the compiler output below as a reference:

```
/tmp/nimble_201292/githubcom_PMunchnimlsp/src/nimlsppkg/baseprotocol.nim(4, 24) Warning: inherit from a more precise exception type like ValueError, IOError or OSError. If these don't suit, inherit from CatchableError or Defect. [InheritFromException]
/tmp/nimble_201292/githubcom_PMunchnimlsp/src/nimlsppkg/utfmapping.nim(1, 8) Warning: imported and not used: 'tables' [UnusedImport]
/tmp/nimble_201292/githubcom_PMunchnimlsp/src/nimlsp.nim(165, 8) Warning: use fileExists; existsFile is deprecated [Deprecated]
```