### PR TITLE
change resolveProvider default value to false

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -237,7 +237,7 @@ while true:
             )), # ?: TextDocumentSyncOptions or int or float
             hoverProvider = some(true), # ?: bool
             completionProvider = some(create(CompletionOptions,
-              resolveProvider = some(true),
+              resolveProvider = some(false),
               triggerCharacters = some(@[".", " "])
             )), # ?: CompletionOptions
             signatureHelpProvider = none(SignatureHelpOptions),


### PR DESCRIPTION
if the resolveProvider default is true,vscode client always request "completion/reslove",this will cause the completion view to keep loading...