### PR TITLE
Group suggested completions by name, strip '`' characters

### DIFF
--- a/src/nimlsppkg/suggestlib.nim
+++ b/src/nimlsppkg/suggestlib.nim
@@ -44,6 +44,10 @@ proc `$`*(suggestion: Suggest): string =
   result.add "prefix: " & $suggestion.prefix
   result.add ")"
 
+func collapseByIdentifier*(suggestion: Suggest): string =
+  ## Function to create an identifier that can be used to remove duplicates in a list
+  suggestion.qualifiedPath[^1] & "__" & $suggestion.symKind.TSymKind
+
 func nimSymToLSPKind*(suggest: Suggest): CompletionItemKind =
   case $suggest.symKind.TSymKind:
   of "skConst": CompletionItemKind.Value


### PR DESCRIPTION
As  suggested in https://github.com/PMunch/nimlsp/issues/90, remove duplicates from list, combining their information into some simple text.

What do you think @AmjadHD? I'm also considering to combine all the signatures into a list and put them in the documentation field so it would be possible to see all the available ones more easily.