### PR TITLE
Ensure the storage directory is calculated during runtime

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -11,7 +11,6 @@ import uri
 import osproc
 
 const
-  storage = getTempDir() / "nimlsp"
   version = block:
     var version = "0.0.0"
     let nimbleFile = staticRead(currentSourcePath().parentDir().parentDir() / "nimlsp.nimble")
@@ -30,6 +29,7 @@ type
     uri: string
 
 var nimpath = explicitSourcePath
+var storage = getTempDir() / "nimlsp"
 
 discard existsOrCreateDir(storage)
 


### PR DESCRIPTION
When building nimlsp in a sandbox (before installing it on a system) the
temporary directory might be different. In my case I was building nimlsp
with Nix which caused nimlsp to hardcode `/build/nimlsp` as storage
directory. That directory only exists within the build sandbox and even
if it would exist outside of the sandbox it wouldn't be writable by the
average user.

Side note: This is the very first Nim code I've ever "written".