### PR TITLE
Enable signatureHelp

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Status  LSP Command
 ☑ DONE  textDocument/hover
 ☑ DONE  textDocument/rename
 ☑ DONE  textDocument/references
-☐ TODO  textDocument/signatureHelp
+☑ DONE  textDocument/signatureHelp
 ☑ DONE  textDocument/publishDiagnostics
 ☐ TODO  workspace/symbol
 ======  ================================

--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -240,10 +240,9 @@ while true:
               resolveProvider = some(false),
               triggerCharacters = some(@[".", " "])
             )), # ?: CompletionOptions
-            signatureHelpProvider = none(SignatureHelpOptions),
-            #signatureHelpProvider = some(create(SignatureHelpOptions,
-            #  triggerCharacters = some(@["(", ","])
-            #)), # ?: SignatureHelpOptions
+            signatureHelpProvider = some(create(SignatureHelpOptions,
+              triggerCharacters = some(@["(", ","])
+            )), # ?: SignatureHelpOptions
             definitionProvider = some(true), #?: bool
             typeDefinitionProvider = none(bool), #?: bool or TextDocumentAndStaticRegistrationOptions
             implementationProvider = none(bool), #?: bool or TextDocumentAndStaticRegistrationOptions
@@ -456,19 +455,25 @@ while true:
                   none(string)
                 ).JsonNode
               message.respond response
-        #of "textDocument/signatureHelp":
-        #  if message["params"].isSome:
-        #    let signRequest = message["params"].unsafeGet
-        #    whenValid(signRequest, TextDocumentPositionParams):
-        #      let
-        #        fileuri = signRequest["textDocument"]["uri"].getStr
-        #        filestash = storage / (hash(fileuri).toHex & ".nim" )
-        #      debugEcho "Got signature request for URI: ", fileuri, " copied to " & filestash
-        #      let
-        #        rawLine = signRequest["position"]["line"].getInt
-        #        rawChar = signRequest["position"]["character"].getInt
-        #        suggestions = getNimsuggest(fileuri).con(uriToPath(fileuri), dirtyfile = filestash, rawLine + 1, rawChar)
+        of "textDocument/signatureHelp":
+          message.textDocumentRequest(TextDocumentPositionParams, sigHelpRequest):
+            let suggestions = getNimsuggest(fileuri).con(uriToPath(fileuri), dirtyfile = filestash, rawLine + 1, rawChar)
+            var signatures = newSeq[SignatureInformation]()
+            for suggestion in suggestions:
+              var label = suggestion.qualifiedPath.join(".")
+              if suggestion.forth != "":
+                label &= ": " & suggestion.forth
+              signatures.add create(SignatureInformation,
+                label = label,
+                documentation = some(suggestion.nimDocstring),
+                parameters = none(seq[ParameterInformation])
+              )
 
+            message.respond create(SignatureHelp,
+              signatures = signatures,
+              activeSignature = some(0),
+              activeParameter = some(0)
+            ).JsonNode
         else:
           debugEcho "Unknown request"
       continue
@@ -628,4 +633,3 @@ while true:
   except CatchableError as e:
     debugEcho "Got exception: ", e.msg
     continue
-

--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -457,6 +457,9 @@ while true:
               message.respond response
         of "textDocument/signatureHelp":
           message.textDocumentRequest(TextDocumentPositionParams, sigHelpRequest):
+            debugEcho "Running equivalent of: con ", uriToPath(fileuri), ";", filestash, ":",
+              rawLine + 1, ":",
+              openFiles[fileuri].fingerTable[rawLine].utf16to8(rawChar)
             let suggestions = getNimsuggest(fileuri).con(uriToPath(fileuri), dirtyfile = filestash, rawLine + 1, rawChar)
             var signatures = newSeq[SignatureInformation]()
             for suggestion in suggestions:


### PR DESCRIPTION
I've enabled basic support for signatureHelp:
![image](https://user-images.githubusercontent.com/48817555/146723342-fdbe3872-b7de-4636-b342-05e02c34ab87.png)

It could definitely be improved; there are a couple of things I tried to add but couldn't get to work:
* set `SignatureHelp.activeParameter`
  * I got an ugly hack working to populate `SignatureInformation.parameters` using regex but ultimately could not find an easy way to get the index of the current parameter.
* get signature help to trigger with Nim's command syntax (` ` and `:`)
  * Not sure if this was a limitation of the vim plugins I was using.
 