### PR TITLE
Add a fix for windows for proper URI handling (#87)

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -103,10 +103,18 @@ proc pathToUri(path: string): string =
   # the / character, meaning a full file path can be passed in without breaking
   # it.
   result = newStringOfCap(path.len + path.len shr 2) # assume 12% non-alnum-chars
+  when defined(windows):
+    result.add '/'
   for c in path:
     case c
     # https://tools.ietf.org/html/rfc3986#section-2.3
     of 'a'..'z', 'A'..'Z', '0'..'9', '-', '.', '_', '~', '/': add(result, c)
+    of '\\':
+      when defined(windows):
+        result.add '/'
+      else:
+        result.add '%'
+        result.add toHex(ord(c), 2)
     else:
       add(result, '%')
       add(result, toHex(ord(c), 2))


### PR DESCRIPTION
This PR implements the fix for the issue discussed in #87.

This issue made the "Reference" feature and the "Goto Definition" features not work on Windows.
This affected Sublime Text and CudaText and maybe other editors.

Credit goes to veksha for suggesting this patch.

`nimble test` works.