### PR TITLE
Show first signature if overload exists

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -289,14 +289,11 @@ while true:
                   detail =
                     if seenTimes == 1: some(nimSymDetails(suggestion))
                     else: some(nimSymDetails(suggestions[0]) & " (+ " & $(seenTimes - 1) & " overload(s))")
-                  docstring =
-                    if seenTimes == 1: some(suggestion.nimDocstring)
-                    else: none(string)
                 completionItems.add create(CompletionItem,
                   label = suggestion.qualifiedPath[^1].strip(chars = {'`'}),
                   kind = some(nimSymToLSPKind(suggestion).int),
                   detail = detail,
-                  documentation = docstring,
+                  documentation = some(suggestion.nimDocstring),
                   deprecated = none(bool),
                   preselect = none(bool),
                   sortText = none(string),

--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -288,7 +288,7 @@ while true:
                   seenTimes = seenLabels[collapsed]
                   detail =
                     if seenTimes == 1: some(nimSymDetails(suggestion))
-                    else: some(nimSymDetails(suggestions[0]) & " (+ " & $(seenTimes - 1) & " overload(s))")
+                    else: some(nimSymDetails(suggestion) & " (+ " & $(seenTimes - 1) & " overload(s))")
                 completionItems.add create(CompletionItem,
                   label = suggestion.qualifiedPath[^1].strip(chars = {'`'}),
                   kind = some(nimSymToLSPKind(suggestion).int),

--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -288,7 +288,7 @@ while true:
                   seenTimes = seenLabels[collapsed]
                   detail =
                     if seenTimes == 1: some(nimSymDetails(suggestion))
-                    else: some("[" & $seenTimes & " overloads]")
+                    else: some(nimSymDetails(suggestions[0]) & " (+ " & $(seenTimes - 1) & " overload(s))")
                   docstring =
                     if seenTimes == 1: some(suggestion.nimDocstring)
                     else: none(string)


### PR DESCRIPTION
Just a trivial change to make overload details similar to the way the C# LSP does it:

C#:
![image](https://user-images.githubusercontent.com/48817555/147395489-f3a89200-c7f2-44b9-a465-9009a82bdfb7.png)

Nim:
![image](https://user-images.githubusercontent.com/48817555/147395583-da503f90-d99a-468a-9f1b-47219c0a3fbb.png)

This gives a better idea of signatures for overloads when quickly scanning the completion list.
