### PR TITLE
Fix `infoLog` not defined

### DIFF
--- a/src/nimlsppkg/baseprotocol.nim
+++ b/src/nimlsppkg/baseprotocol.nim
@@ -1,6 +1,7 @@
 import std/[asyncdispatch, asyncfile, json, parseutils, streams, strformat,
             strutils]
-
+when defined(debugCommunication):
+  import logger
 
 type
   BaseProtocolError* = object of CatchableError


### PR DESCRIPTION
The error is emitted when running `nimble debug [-d:debugLogging]`