### PR TITLE
Fix infinite loop regression on Windows

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -149,7 +149,7 @@ proc getProjectFile(fileUri: string): string =
   var
     path = dir
     certainty = None
-  while path.len > 0 and path != "/":
+  while not path.isRootDir:
     let
       (dir, fname, ext) = path.splitFile()
       current = fname & ext


### PR DESCRIPTION
The issue is that an infinite loop occurs in every run of nimlsp following this commit in Nim: 23e0160af283bb0bb573a86145e6c1c792780d49.

`splitFile` has changed behavior on Windows. `splitFile("D:").dir` now returns "D:" instead of "". This behavior is now consistent with Linux's `splitFile` where `splitFile("/").dir` returns `/`.

The condition `path != "/"` in nimlsp code assumes that that the root component is a Linux root component. This adds support for Windows roots by using the platform-independent `isRootDir` proc. `path.len > 0` is removed because `""` counts as a root dir.

Fixes: #140