### PR TITLE
Forced ordering of responses to prevent them from ending up alphabetical

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -295,7 +295,8 @@ proc main(ins: Stream | AsyncFile, outs: Stream | AsyncFile) {.multisync.} =
                 addedSuggestions: HashSet[string]
               for suggestion in suggestions:
                 seenLabels.inc suggestion.collapseByIdentifier
-              for suggestion in suggestions:
+              for i in countUp(0,suggestions.len-1):
+                let suggestion = suggestions[i]
                 let collapsed = suggestion.collapseByIdentifier
                 if not addedSuggestions.contains collapsed:
                   addedSuggestions.incl collapsed
@@ -311,7 +312,7 @@ proc main(ins: Stream | AsyncFile, outs: Stream | AsyncFile) {.multisync.} =
                     documentation = some(suggestion.doc),
                     deprecated = none(bool),
                     preselect = none(bool),
-                    sortText = none(string),
+                    sortText = some(fmt"{i:04}"),
                     filterText = none(string),
                     insertText = none(string),
                     insertTextFormat = none(int),

--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -295,9 +295,8 @@ proc main(ins: Stream | AsyncFile, outs: Stream | AsyncFile) {.multisync.} =
                 addedSuggestions: HashSet[string]
               for suggestion in suggestions:
                 seenLabels.inc suggestion.collapseByIdentifier
-              for i in countUp(0,suggestions.len-1):
-                let suggestion = suggestions[i]
-                let collapsed = suggestion.collapseByIdentifier
+              for i in 0..suggestions.high:
+                let collapsed = suggestions[i].collapseByIdentifier
                 if not addedSuggestions.contains collapsed:
                   addedSuggestions.incl collapsed
                   let


### PR DESCRIPTION
Currently, results in vscode are shown alphabetic which complete is a waste considering nimsuggest goes to the trouble of sorting suggestions.
This sets sortext which tells the client that the server would like the items in a particular order