### PR TITLE
Add Emacs Eglot config to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,6 +194,13 @@ With lsp-mode and use-package:
      :hook
      (nim-mode . lsp))
 
+Or with Eglot
+
+.. code:: emacs-lisp
+
+(add-to-list 'eglot-server-programs
+             '(nim-mode "nimlsp"))
+
 Intellij
 -------
 You will need to install the `LSP support plugin <https://plugins.jetbrains.com/plugin/10209-lsp-support>`_.


### PR DESCRIPTION
Eglot is now built in to Emacs and is the other main LSP client implementation besides `lsp-mode`.