### PR TITLE
Explicitly bind logging procs in templates

### DIFF
--- a/src/nimlsppkg/logger.nim
+++ b/src/nimlsppkg/logger.nim
@@ -31,6 +31,7 @@ template warnLog*(args: varargs[string, `$`]) =
 type FrameDirection* = enum In, Out
 
 template frameLog*(direction: FrameDirection, args: varargs[string, `$`]) =
+  bind info
   let oldFmtStr = rollingLog.fmtStr
   case direction:
   of Out: rollingLog.fmtStr = "<< "

--- a/src/nimlsppkg/logger.nim
+++ b/src/nimlsppkg/logger.nim
@@ -7,20 +7,24 @@ let rollingLog = newRollingFileLogger(storage / "nimlsp.log")
 addHandler(rollingLog)
 
 template debugLog*(args: varargs[string, `$`]) =
+  bind debug
   when defined(debugLogging):
     debug join(args)
     flushFile rollingLog.file
 
 template infoLog*(args: varargs[string, `$`]) =
+  bind info
   when defined(debugLogging):
     info join(args)
     flushFile rollingLog.file
 
 template errorLog*(args: varargs[string, `$`]) =
+  bind error
   when defined(debugLogging):
     error join(args)
 
 template warnLog*(args: varargs[string, `$`]) =
+  bind warn
   when defined(debugLogging):
     warn join(args)
 


### PR DESCRIPTION
The logging templates in `logger` reference procs like `error`, `info`, `warn` etc. from the `logging` module. These are implicitly bound, as they have exactly 1 overload in the scope of the template definitions (https://github.com/nim-lang/Nim/issues/11184).

If this behavior of Nim or the context in `logger` were to change, these would start preferring procs like `macros.error` instead and cause issues. Explicitly binding them keeps the current behavior consistent.

An alternative would be to directly call `logging.error join(args)` etc.