### PR TITLE
Support hierarchical document outline via `DocumentSymbol`

### DIFF
--- a/src/nimlsppkg/capabilities.nim
+++ b/src/nimlsppkg/capabilities.nim
@@ -1,0 +1,10 @@
+## Helper functions to check what the client supports
+
+import std/json
+
+using caps: ClientCapabilities
+
+func supportsHierarchicalSymbols*(caps): bool =
+  ## True if the client supports having heirarchal
+  ## symbols in the document outline
+  JsonNode(caps){"textDocument", "documentSymbol", "hierarchicalDocumentSymbolSupport"} == %true

--- a/src/nimlsppkg/messageenums.nim
+++ b/src/nimlsppkg/messageenums.nim
@@ -46,6 +46,9 @@ type
     Operator = 25,
     TypeParameter = 26
 
+  SymbolTag* = enum
+    Deprecated = 1
+
   CompletionItemKind* {.pure.} = enum
     Text = 1,
     Method = 2,

--- a/src/nimlsppkg/messages.nim
+++ b/src/nimlsppkg/messages.nim
@@ -519,7 +519,7 @@ jsonSchema:
     detail ?: string
     kind: int # SymbolKind
     tags ?: int[] # SymbolTag[]
-    range: Range
+    "range": Range
     selectionRange: Range
     children ?: DocumentSymbol[]
 

--- a/src/nimlsppkg/messages.nim
+++ b/src/nimlsppkg/messages.nim
@@ -175,6 +175,7 @@ jsonSchema:
   DocumentSymbolCapability:
     dynamicRegistration ?: bool
     symbolKind ?: SymbolKindCapability
+    hierarchicalDocumentSymbolSupport ?: bool
 
   FormattingCapability:
     dynamicRegistration ?: bool
@@ -512,6 +513,15 @@ jsonSchema:
     deprecated ?: bool
     location: Location
     containerName ?: string
+
+  DocumentSymbol:
+    name: string
+    detail ?: string
+    kind: int # SymbolKind
+    tags ?: int[] # SymbolTag[]
+    range: Range
+    selectionRange: Range
+    children ?: DocumentSymbol[]
 
   CodeActionParams:
     textDocument: TextDocumentIdentifier

--- a/src/nimlsppkg/suggestlib.nim
+++ b/src/nimlsppkg/suggestlib.nim
@@ -43,6 +43,7 @@ func nimSymToLSPKind*(suggest: byte): SymbolKind =
   case TSymKind(suggest):
   of skConst: SymbolKind.Constant
   of skEnumField: SymbolKind.EnumMember
+  of skField: SymbolKind.Field
   of skIterator: SymbolKind.Function
   of skConverter: SymbolKind.Function
   of skLet: SymbolKind.Variable


### PR DESCRIPTION
This uses `DocumentSymbol` if the client supports it which allows enum/type fields to be shown

```nim
proc test() = discard

type
  Something = object
    hello*: tuple[name: string]
  Test = enum
    Colour
```

Produces

![image](https://github.com/PMunch/nimlsp/assets/19339842/45db0bb9-9e03-4de2-9ad0-489b44f8d466)
