### PR TITLE
Add `-d:nimlspDontWarnAboutNimVersion`

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -214,8 +214,10 @@ proc checkVersion(outs: Stream | AsyncFile) {.multisync.} =
       version = nimoutput[versionStart..<nimoutput.find(" ", versionStart)]
       #hashStart = nimoutput.find("git hash") + 10
       #hash = nimoutput[hashStart..nimoutput.find("\n", hashStart)]
-    if version != NimVersion:
-      await outs.notify("window/showMessage", create(ShowMessageParams, MessageType.Warning.int, message = "Current Nim version does not match the one NimLSP is built against " & version & " != " & NimVersion).JsonNode)
+
+    when not defined(nimlspDontWarnAboutNimVersion):
+      if version != NimVersion:
+        await outs.notify("window/showMessage", create(ShowMessageParams, MessageType.Warning.int, message = "Current Nim version does not match the one NimLSP is built against " & version & " != " & NimVersion).JsonNode)
 
 proc main(ins: Stream | AsyncFile, outs: Stream | AsyncFile) {.multisync.} =
   when outs is AsyncFile:


### PR DESCRIPTION
This just makes life a bit easier for the Nix packaging. If enabled, nimlsp will no longer warn about a Nim version mismatch. \
The NixOS package currently compiles nimlsp against Nim 2.0.0 due to regressions* in the Nim 2.2.x line of compilers. \
However, this gives out a silly little warning about a version mismatch. This new compile-time flag stops nimlsp from doing that.
