### PR TITLE
fix(nimlsp): move Nim version check to run after initialize

### DIFF
--- a/src/nimlsp.nim
+++ b/src/nimlsp.nim
@@ -218,10 +218,6 @@ proc checkVersion(outs: Stream | AsyncFile) {.multisync.} =
       await outs.notify("window/showMessage", create(ShowMessageParams, MessageType.Warning.int, message = "Current Nim version does not match the one NimLSP is built against " & version & " != " & NimVersion).JsonNode)
 
 proc main(ins: Stream | AsyncFile, outs: Stream | AsyncFile) {.multisync.} =
-  when outs is AsyncFile:
-    await checkVersion(outs)
-  else:
-    checkVersion(outs)
   while true:
     try:
       debugLog "Trying to read frame"
@@ -278,6 +274,10 @@ proc main(ins: Stream | AsyncFile, outs: Stream | AsyncFile) {.multisync.} =
               experimental = none(JsonNode) #?: any
             )).JsonNode
             await outs.respond(message,resp)
+            when outs is AsyncFile:
+              await checkVersion(outs)
+            else:
+              checkVersion(outs)
           of "textDocument/completion":
             message.textDocumentRequest(CompletionParams, compRequest):
               debugLog "Running equivalent of: sug ", uriToPath(fileuri), ";", filestash, ":",


### PR DESCRIPTION
Previously,  was called at the start of , before the client had sent an initialize request. This caused potential protocol violations or confused clients.

Now the version check is deferred to run only after receiving and handling the initialize request, ensuring it adheres to the LSP handshake and avoids premature messages.